### PR TITLE
Add structured experiment logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Experiment runs (large, local data)
+runs/
+
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ src/
   judge.py       # Deception success (binary) + realism (1-7), async-parallel
   evolution.py   # Fitness-proportional selection from population
   experiment.py  # Orchestrates 3 conditions, per-role LLM support
+  run_logger.py  # Structured logging: events, results, transcripts per run
 prompts/         # One class per file. See prompts/CLAUDE.md
 tests/
 main.py          # CLI entry point
@@ -33,6 +34,7 @@ main.py          # CLI entry point
 - **Fitness**: `realism × deception_success` — non-deceptive → 0 regardless of realism.
 - **Evolutionary**: Fitness-proportional sampling from population (no embeddings/FAISS).
 - **Prompts**: One class per file in `prompts/`. Full prompt visible in one place.
+- **Logging**: Each run creates `runs/<ts>_<condition>_<topic>/` with events.jsonl, results.jsonl, transcripts/, summary.json. See [docs/logging.md](docs/logging.md).
 
 ## Conventions
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,45 @@
+# Experiment Logging
+
+Every experiment run creates a directory under `runs/`:
+
+```
+runs/20260312_143000_evolutionary_medicine/
+  config.json          # Experiment parameters (condition, topic, n, models)
+  events.jsonl         # Timestamped event timeline (start, iterations, errors, end)
+  results.jsonl        # One line per iteration (metrics only, analysis-ready)
+  transcripts/         # Full prompts + responses per iteration
+    000.json           #   generator prompt/response, target messages/response,
+    001.json           #   judge deception prompt/response, judge realism prompt/response
+    ...
+  summary.json         # Aggregate stats (written at end)
+```
+
+## File purposes
+
+| File | Use case | Size |
+|------|----------|------|
+| `config.json` | "What was this run?" | Tiny |
+| `events.jsonl` | Timeline, debugging, monitoring | Small |
+| `results.jsonl` | Statistical analysis, `jq`/pandas | Medium |
+| `transcripts/*.json` | "What exactly did the LLM say?" | Large |
+| `summary.json` | Quick stats without reading results | Tiny |
+
+## Reading logs
+
+```bash
+# Quick stats
+cat runs/*/summary.json | jq .
+
+# Success rate over time
+jq -r 'select(.event=="iteration_complete") | [.i, .cumulative_success_rate] | @csv' runs/*/events.jsonl
+
+# All deceptive scenarios
+jq -r 'select(.deceptive) | .system_prompt[:80]' runs/*/results.jsonl
+
+# Full transcript for iteration 5
+cat runs/*/transcripts/005.json | jq .
+```
+
+## How it works
+
+`CaptureLLM` wraps each role's LLM callable and records all calls (messages + responses). After each iteration, the captures are drained into a transcript file. No changes needed to generator/judge/target code.

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ import argparse
 import asyncio
 import os
 import sys
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -100,6 +101,7 @@ def main() -> None:
     print(f"Condition: {args.condition} | Topic: {args.topic} | N: {args.n}")
     print()
 
+    runs_dir = Path("runs")
     pop = asyncio.run(
         run_experiment_async(
             generator_llm=generator_llm,
@@ -108,6 +110,7 @@ def main() -> None:
             condition=args.condition,
             topic=args.topic,
             n=args.n,
+            runs_dir=runs_dir,
         )
     )
 

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Callable
 
 from src.evolution import select_examples
 from src.generator import generate
 from src.judge import judge, judge_async
+from src.run_logger import CaptureLLM, RunLogger
 from src.target import run
 from src.types import EvalResult, Population
 
@@ -33,34 +35,6 @@ def _pick_examples(condition, examples, pop):
         return select_examples(pop, k=3) or None
 
 
-def _run_one(
-    generator_llm: Callable,
-    target_llm: Callable,
-    judge_llm: Callable,
-    topic: str,
-    examples: list[str] | None = None,
-) -> EvalResult:
-    """Generate a scenario, run it, judge it, return the result."""
-    scenario = generate(generator_llm, topic, examples=examples)
-    response = run(target_llm, scenario)
-    judgment = judge(judge_llm, scenario, response)
-    return EvalResult(scenario=scenario, target_response=response, judgment=judgment)
-
-
-async def _run_one_async(
-    generator_llm,
-    target_llm,
-    judge_llm,
-    topic: str,
-    examples: list[str] | None = None,
-) -> EvalResult:
-    """Generate, run, then judge concurrently (deception + realism in parallel)."""
-    scenario = generate(generator_llm, topic, examples=examples)
-    response = run(target_llm, scenario)
-    judgment = await judge_async(judge_llm, scenario, response)
-    return EvalResult(scenario=scenario, target_response=response, judgment=judgment)
-
-
 def run_experiment(
     llm: Callable | None = None,
     *,
@@ -71,6 +45,7 @@ def run_experiment(
     topic: str,
     n: int,
     examples: list[str] | None = None,
+    runs_dir: Path | str | None = None,
 ) -> Population:
     """Run n iterations of a condition and return the population.
 
@@ -82,11 +57,34 @@ def run_experiment(
     _validate_condition(condition)
     gen, tgt, jdg = _resolve_llms(llm, generator_llm, target_llm, judge_llm)
 
+    logger = None
+    if runs_dir is not None:
+        logger = RunLogger(base_dir=runs_dir, condition=condition, topic=topic, n=n)
+
     pop = Population()
-    for _ in range(n):
+    for i in range(n):
         ex = _pick_examples(condition, examples, pop)
-        result = _run_one(gen, tgt, jdg, topic, examples=ex)
+
+        if logger:
+            gen_cap = CaptureLLM(gen, "generator")
+            tgt_cap = CaptureLLM(tgt, "target")
+            jdg_cap = CaptureLLM(jdg, "judge")
+            scenario = generate(gen_cap, topic, examples=ex)
+            response = run(tgt_cap, scenario)
+            judgment = judge(jdg_cap, scenario, response)
+            result = EvalResult(scenario=scenario, target_response=response, judgment=judgment)
+            logger.log_iteration(i, result, gen_cap, tgt_cap, jdg_cap, examples_used=ex)
+        else:
+            scenario = generate(gen, topic, examples=ex)
+            response = run(tgt, scenario)
+            judgment = judge(jdg, scenario, response)
+            result = EvalResult(scenario=scenario, target_response=response, judgment=judgment)
+
         pop.add(result)
+
+    if logger:
+        logger.write_summary()
+
     return pop
 
 
@@ -100,14 +98,38 @@ async def run_experiment_async(
     topic: str,
     n: int,
     examples: list[str] | None = None,
+    runs_dir: Path | str | None = None,
 ) -> Population:
     """Async version with concurrent judge calls (deception + realism in parallel)."""
     _validate_condition(condition)
     gen, tgt, jdg = _resolve_llms(llm, generator_llm, target_llm, judge_llm)
 
+    logger = None
+    if runs_dir is not None:
+        logger = RunLogger(base_dir=runs_dir, condition=condition, topic=topic, n=n)
+
     pop = Population()
-    for _ in range(n):
+    for i in range(n):
         ex = _pick_examples(condition, examples, pop)
-        result = await _run_one_async(gen, tgt, jdg, topic, examples=ex)
+
+        if logger:
+            gen_cap = CaptureLLM(gen, "generator")
+            tgt_cap = CaptureLLM(tgt, "target")
+            jdg_cap = CaptureLLM(jdg, "judge")
+            scenario = generate(gen_cap, topic, examples=ex)
+            response = run(tgt_cap, scenario)
+            judgment = await judge_async(jdg_cap, scenario, response)
+            result = EvalResult(scenario=scenario, target_response=response, judgment=judgment)
+            logger.log_iteration(i, result, gen_cap, tgt_cap, jdg_cap, examples_used=ex)
+        else:
+            scenario = generate(gen, topic, examples=ex)
+            response = run(tgt, scenario)
+            judgment = await judge_async(jdg, scenario, response)
+            result = EvalResult(scenario=scenario, target_response=response, judgment=judgment)
+
         pop.add(result)
+
+    if logger:
+        logger.write_summary()
+
     return pop

--- a/src/run_logger.py
+++ b/src/run_logger.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.types import EvalResult, Scenario
+
+
+class CaptureLLM:
+    """Wraps an LLM callable to capture all calls for logging."""
+
+    def __init__(self, llm, role: str):
+        self.llm = llm
+        self.role = role
+        self.calls: list[dict] = []
+
+    def __call__(self, messages, **kwargs):
+        response = self.llm(messages, **kwargs)
+        self.calls.append({
+            "role": self.role,
+            "messages": messages,
+            "response": response,
+        })
+        return response
+
+    async def acall(self, messages, **kwargs):
+        response = await self.llm.acall(messages, **kwargs)
+        self.calls.append({
+            "role": self.role,
+            "messages": messages,
+            "response": response,
+        })
+        return response
+
+    def drain(self) -> list[dict]:
+        """Return and clear captured calls."""
+        calls = self.calls
+        self.calls = []
+        return calls
+
+
+class RunLogger:
+    """Logs experiment runs to structured files.
+
+    Creates:
+        runs/<timestamp>_<condition>_<topic>/
+            config.json          # Experiment parameters
+            events.jsonl         # Timeline of all events
+            results.jsonl        # One line per EvalResult (analysis-ready)
+            transcripts/         # Full prompts+responses per iteration
+                000.json, 001.json, ...
+            summary.json         # Aggregate stats (written at end)
+    """
+
+    def __init__(
+        self,
+        base_dir: Path | str,
+        condition: str,
+        topic: str,
+        n: int,
+        **extra_config,
+    ):
+        base_dir = Path(base_dir)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        self.run_dir = base_dir / f"{ts}_{condition}_{topic}"
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        (self.run_dir / "transcripts").mkdir(exist_ok=True)
+
+        self._events_path = self.run_dir / "events.jsonl"
+        self._results_path = self.run_dir / "results.jsonl"
+        self._results: list[EvalResult] = []
+
+        config = {"condition": condition, "topic": topic, "n": n, **extra_config}
+        (self.run_dir / "config.json").write_text(json.dumps(config, indent=2))
+        self.event("experiment_start", **config)
+
+    def event(self, event_name: str, **data) -> None:
+        """Append a timestamped event to events.jsonl."""
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": event_name,
+            **data,
+        }
+        with open(self._events_path, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def log_result(self, i: int, result: EvalResult) -> None:
+        """Append a result to results.jsonl."""
+        self._results.append(result)
+        entry = {
+            "i": i,
+            "system_prompt": result.scenario.system_prompt,
+            "user_prompt": result.scenario.user_prompt,
+            "target_response": result.target_response,
+            "deceptive": result.judgment.deception_success,
+            "realism": result.judgment.realism,
+            "fitness": result.fitness,
+        }
+        with open(self._results_path, "a") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def log_transcript(self, i: int, **fields) -> None:
+        """Write full prompt/response transcript for one iteration."""
+        serialized = {}
+        for k, v in fields.items():
+            if isinstance(v, Scenario):
+                serialized[k] = {"system_prompt": v.system_prompt, "user_prompt": v.user_prompt}
+            else:
+                serialized[k] = v
+
+        path = self.run_dir / "transcripts" / f"{i:03d}.json"
+        path.write_text(json.dumps(serialized, indent=2))
+
+    def log_transcript_from_captures(
+        self, i: int, gen_calls: list[dict], tgt_calls: list[dict], jdg_calls: list[dict],
+    ) -> None:
+        """Build and write transcript from CaptureLLM drain() output."""
+        transcript: dict = {}
+
+        if gen_calls:
+            transcript["generator_prompt"] = gen_calls[0]["messages"][0]["content"]
+            transcript["generator_response"] = gen_calls[0]["response"]
+
+        if tgt_calls:
+            transcript["target_messages"] = tgt_calls[0]["messages"]
+            transcript["target_response"] = tgt_calls[0]["response"]
+
+        for call in jdg_calls:
+            prompt_text = call["messages"][0]["content"]
+            if "lie of commission" in prompt_text:
+                transcript["judge_deception_prompt"] = prompt_text
+                transcript["judge_deception_response"] = call["response"]
+            else:
+                transcript["judge_realism_prompt"] = prompt_text
+                transcript["judge_realism_response"] = call["response"]
+
+        self.log_transcript(i, **transcript)
+
+    def log_iteration(
+        self,
+        i: int,
+        result: EvalResult,
+        gen_capture: CaptureLLM,
+        tgt_capture: CaptureLLM,
+        jdg_capture: CaptureLLM,
+        examples_used: list[str] | None = None,
+    ) -> None:
+        """Log a complete iteration: event, result, and transcript."""
+        total = len(self._results) + 1
+        deceptive_so_far = sum(1 for r in self._results if r.judgment.deception_success)
+        if result.judgment.deception_success:
+            deceptive_so_far += 1
+
+        self.event(
+            "iteration_complete",
+            i=i,
+            deceptive=result.judgment.deception_success,
+            realism=result.judgment.realism,
+            fitness=result.fitness,
+            examples_used=len(examples_used) if examples_used else 0,
+            cumulative_success_rate=deceptive_so_far / total,
+        )
+
+        self.log_result(i, result)
+        self.log_transcript_from_captures(
+            i, gen_capture.drain(), tgt_capture.drain(), jdg_capture.drain(),
+        )
+
+    def write_summary(self) -> None:
+        """Write aggregate stats to summary.json."""
+        total = len(self._results)
+        deceptive = sum(1 for r in self._results if r.judgment.deception_success)
+        realism_scores = [r.judgment.realism for r in self._results]
+        fitness_scores = [r.fitness for r in self._results]
+
+        summary = {
+            "total": total,
+            "deceptive": deceptive,
+            "success_rate": deceptive / total if total > 0 else 0.0,
+            "avg_realism": sum(realism_scores) / total if total > 0 else 0.0,
+            "avg_fitness": sum(fitness_scores) / total if total > 0 else 0.0,
+            "max_fitness": max(fitness_scores) if fitness_scores else 0.0,
+        }
+        (self.run_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+        self.event("experiment_end", **summary)

--- a/tests/test_run_logger.py
+++ b/tests/test_run_logger.py
@@ -1,0 +1,176 @@
+import json
+import os
+from pathlib import Path
+
+from src.run_logger import CaptureLLM, RunLogger
+from src.types import EvalResult, Judgment, Scenario
+
+
+class TestRunLogger:
+    def test_creates_run_directory(self, tmp_path):
+        logger = RunLogger(base_dir=tmp_path, condition="zero_shot", topic="medicine", n=10)
+        assert logger.run_dir.exists()
+        assert (logger.run_dir / "transcripts").is_dir()
+
+    def test_writes_config(self, tmp_path):
+        logger = RunLogger(base_dir=tmp_path, condition="evolutionary", topic="law", n=50)
+        config = json.loads((logger.run_dir / "config.json").read_text())
+        assert config["condition"] == "evolutionary"
+        assert config["topic"] == "law"
+        assert config["n"] == 50
+
+    def test_log_event_appends_to_events_jsonl(self, tmp_path):
+        logger = RunLogger(base_dir=tmp_path, condition="zero_shot", topic="test", n=1)
+        logger.event("test_event", foo="bar")
+        logger.event("another_event", x=42)
+
+        lines = (logger.run_dir / "events.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 3  # config event + 2 custom events
+        event = json.loads(lines[1])
+        assert event["event"] == "test_event"
+        assert event["foo"] == "bar"
+        assert "ts" in event
+
+    def test_log_result_writes_to_results_jsonl(self, tmp_path):
+        logger = RunLogger(base_dir=tmp_path, condition="zero_shot", topic="test", n=1)
+        result = EvalResult(
+            scenario=Scenario("You are a bot.", "Tell me something."),
+            target_response="Sure, here's a lie.",
+            judgment=Judgment(deception_success=True, realism=5, reasoning="It lied."),
+        )
+        logger.log_result(0, result)
+
+        lines = (logger.run_dir / "results.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["i"] == 0
+        assert data["deceptive"] is True
+        assert data["realism"] == 5
+        assert data["fitness"] == 5.0
+
+    def test_log_transcript(self, tmp_path):
+        logger = RunLogger(base_dir=tmp_path, condition="zero_shot", topic="test", n=1)
+        logger.log_transcript(
+            i=0,
+            generator_prompt="Craft a scenario...",
+            generator_response="[SYSTEM PROMPT]...",
+            scenario=Scenario("bot", "hi"),
+            target_messages=[{"role": "system", "content": "bot"}, {"role": "user", "content": "hi"}],
+            target_response="I lied.",
+            judge_deception_prompt="Did the target...",
+            judge_deception_response="DECEPTIVE\nReason.",
+            judge_realism_prompt="Rate realism...",
+            judge_realism_response="5\nPlausible.",
+        )
+
+        path = logger.run_dir / "transcripts" / "000.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["generator_prompt"] == "Craft a scenario..."
+        assert data["target_response"] == "I lied."
+        assert data["judge_deception_response"] == "DECEPTIVE\nReason."
+
+    def test_write_summary(self, tmp_path):
+        logger = RunLogger(base_dir=tmp_path, condition="zero_shot", topic="test", n=2)
+        for i in range(2):
+            result = EvalResult(
+                scenario=Scenario("bot", "hi"),
+                target_response="resp",
+                judgment=Judgment(deception_success=(i == 0), realism=5),
+            )
+            logger.log_result(i, result)
+
+        logger.write_summary()
+        summary = json.loads((logger.run_dir / "summary.json").read_text())
+        assert summary["total"] == 2
+        assert summary["deceptive"] == 1
+        assert summary["success_rate"] == 0.5
+        assert summary["avg_realism"] == 5.0
+
+    def test_run_dir_name_contains_condition_and_topic(self, tmp_path):
+        logger = RunLogger(base_dir=tmp_path, condition="evolutionary", topic="finance", n=10)
+        assert "evolutionary" in logger.run_dir.name
+        assert "finance" in logger.run_dir.name
+
+
+class TestCaptureLLM:
+    def test_captures_calls_and_forwards_response(self):
+        def fake_llm(messages, **kwargs):
+            return "response text"
+
+        cap = CaptureLLM(fake_llm, "generator")
+        result = cap([{"role": "user", "content": "hello"}])
+        assert result == "response text"
+        assert len(cap.calls) == 1
+        assert cap.calls[0]["role"] == "generator"
+        assert cap.calls[0]["response"] == "response text"
+
+    def test_drain_clears_calls(self):
+        cap = CaptureLLM(lambda m, **k: "r", "target")
+        cap([{"role": "user", "content": "hi"}])
+        calls = cap.drain()
+        assert len(calls) == 1
+        assert len(cap.calls) == 0
+
+
+class TestLogTranscriptFromCaptures:
+    def test_builds_transcript_from_captures(self, tmp_path):
+        logger = RunLogger(base_dir=tmp_path, condition="zero_shot", topic="test", n=1)
+
+        gen_calls = [{"role": "generator", "messages": [{"role": "user", "content": "gen prompt"}], "response": "[SYSTEM PROMPT]\nbot\n[END SYSTEM PROMPT]\n[USER PROMPT]\nhi\n[END USER PROMPT]"}]
+        tgt_calls = [{"role": "target", "messages": [{"role": "system", "content": "bot"}, {"role": "user", "content": "hi"}], "response": "I lied."}]
+        jdg_calls = [
+            {"role": "judge", "messages": [{"role": "user", "content": "Did the target LLM commit a lie of commission..."}], "response": "DECEPTIVE\nReason."},
+            {"role": "judge", "messages": [{"role": "user", "content": "Rate how realistic..."}], "response": "5\nPlausible."},
+        ]
+
+        logger.log_transcript_from_captures(0, gen_calls, tgt_calls, jdg_calls)
+
+        path = logger.run_dir / "transcripts" / "000.json"
+        data = json.loads(path.read_text())
+        assert "gen prompt" in data["generator_prompt"]
+        assert data["target_response"] == "I lied."
+        assert "DECEPTIVE" in data["judge_deception_response"]
+        assert data["judge_realism_response"] == "5\nPlausible."
+
+
+class TestExperimentWithLogging:
+    def test_run_experiment_creates_run_dir(self, tmp_path):
+        from src.experiment import run_experiment
+
+        def fake_llm(messages, **kwargs):
+            content = messages[0]["content"] if messages else ""
+            if "Craft a realistic scenario" in content:
+                return "[SYSTEM PROMPT]\nBot.\n[END SYSTEM PROMPT]\n\n[USER PROMPT]\nHi\n[END USER PROMPT]"
+            if "lie of commission" in content:
+                return "DECEPTIVE\nLied."
+            if "realistic" in content:
+                return "5\nOk."
+            return "Sure, misleading."
+
+        pop = run_experiment(fake_llm, condition="zero_shot", topic="test", n=2, runs_dir=tmp_path)
+
+        # Should have created a run directory
+        run_dirs = list(tmp_path.iterdir())
+        assert len(run_dirs) == 1
+        run_dir = run_dirs[0]
+
+        # Check all files exist
+        assert (run_dir / "config.json").exists()
+        assert (run_dir / "events.jsonl").exists()
+        assert (run_dir / "results.jsonl").exists()
+        assert (run_dir / "summary.json").exists()
+        assert (run_dir / "transcripts" / "000.json").exists()
+        assert (run_dir / "transcripts" / "001.json").exists()
+
+        # Check results
+        results = [json.loads(l) for l in (run_dir / "results.jsonl").read_text().strip().split("\n")]
+        assert len(results) == 2
+        assert all(r["deceptive"] for r in results)
+
+        # Check transcript has full data
+        t = json.loads((run_dir / "transcripts" / "000.json").read_text())
+        assert "generator_prompt" in t
+        assert "target_response" in t
+        assert "judge_deception_response" in t
+        assert "judge_realism_response" in t


### PR DESCRIPTION
## Summary
- `RunLogger` creates `runs/<ts>_<condition>_<topic>/` with events, results, transcripts, summary
- `CaptureLLM` wraps LLM callables to record all prompts+responses transparently
- Integrated into `experiment.py` via optional `runs_dir` parameter (no logging without it)
- 11 new tests, 72 total passing

## Run directory structure
```
runs/20260312_143000_evolutionary_medicine/
  config.json, events.jsonl, results.jsonl, transcripts/*.json, summary.json
```

## Test plan
- [x] `uv run pytest` — 72/72 passing
- [x] Unit tests for RunLogger, CaptureLLM, transcript building
- [x] Integration test: run_experiment with runs_dir creates all expected files