### PR TITLE
Add Nebius API models and update smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
+NEBIUS_API_KEY=your-nebius-api-key-here
 LLM_BASE_URL=https://api.tokenfactory.us-central1.nebius.com/v1/
 LLM_API_KEY=your-nebius-api-key-here
-LLM_MODEL=zai-org/GLM-5

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,25 +1,43 @@
-"""Quick smoke test against the live API."""
+"""Quick smoke test against Nebius API with per-role models.
+
+Generator: GLM-5 (creative scenario crafting)
+Target:    DeepSeek-V3.2 (strong model to test deception against)
+Judge:     Kimi-K2.5 (independent model for unbiased judging)
+"""
+
+import os
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-from src.llm import LLM
 from src.experiment import run_experiment
+from src.llm import LLM
 
-import os
+NEBIUS_KEY = os.environ["NEBIUS_API_KEY"]
+NEBIUS_US = "https://api.tokenfactory.us-central1.nebius.com/v1/"
+NEBIUS_ME = "https://api.tokenfactory.me-west1.nebius.com/v1/"
 
-llm = LLM(
-    model="zai-org/GLM-5",
-    base_url="https://api.tokenfactory.us-central1.nebius.com/v1/",
-    api_key=os.environ["NEBIUS_API_KEY"],
+generator_llm = LLM(model="zai-org/GLM-5", base_url=NEBIUS_US, api_key=NEBIUS_KEY)
+target_llm = LLM(model="deepseek-ai/DeepSeek-V3.2", base_url=NEBIUS_US, api_key=NEBIUS_KEY)
+judge_llm = LLM(model="moonshotai/Kimi-K2.5", base_url=NEBIUS_ME, api_key=NEBIUS_KEY)
+
+print("Generator: GLM-5 @ us-central1")
+print("Target:    DeepSeek-V3.2 @ us-central1")
+print("Judge:     Kimi-K2.5 @ me-west1")
+print("Running 1 zero-shot iteration on 'medicine'...\n")
+
+pop = run_experiment(
+    generator_llm=generator_llm,
+    target_llm=target_llm,
+    judge_llm=judge_llm,
+    condition="zero_shot",
+    topic="medicine",
+    n=1,
 )
 
-print("Running 1 zero-shot iteration on 'medicine'...")
-pop = run_experiment(llm, condition="zero_shot", topic="medicine", n=1)
-
 result = pop.results[0]
-print(f"\n--- Scenario ---")
+print(f"--- Scenario ---")
 print(f"System prompt: {result.scenario.system_prompt}")
 print(f"User prompt: {result.scenario.user_prompt}")
 print(f"\n--- Target Response ---")

--- a/src/models.py
+++ b/src/models.py
@@ -18,6 +18,7 @@ class ModelConfig:
 
 
 MODELS: dict[str, ModelConfig] = {
+    # --- Local vLLM models (GPU cluster) ---
     "glm-4.7-flash": ModelConfig(
         hf_id="zai-org/GLM-4.7-Flash",
         vllm_args={
@@ -36,6 +37,19 @@ MODELS: dict[str, ModelConfig] = {
             "gpu_memory_utilization": 0.90,
             "max_model_len": 4096,
         },
+    ),
+    # --- Nebius API models (no vllm_args) ---
+    "glm-5": ModelConfig(
+        hf_id="zai-org/GLM-5",
+        api_id="zai-org/GLM-5",
+    ),
+    "kimi-k2.5": ModelConfig(
+        hf_id="moonshotai/Kimi-K2.5",
+        api_id="moonshotai/Kimi-K2.5",
+    ),
+    "deepseek-v3.2": ModelConfig(
+        hf_id="deepseek-ai/DeepSeek-V3.2",
+        api_id="deepseek-ai/DeepSeek-V3.2",
     ),
 }
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,6 +53,14 @@ class TestRegistry:
         cfg = MODELS["gpt-oss-120b"]
         assert cfg.vllm_args["enforce_eager"] is True
 
-    def test_all_models_have_tensor_parallel(self):
+    def test_vllm_models_have_tensor_parallel(self):
         for name, cfg in MODELS.items():
-            assert "tensor_parallel_size" in cfg.vllm_args, f"{name} missing TP"
+            if cfg.vllm_args:
+                assert "tensor_parallel_size" in cfg.vllm_args, f"{name} missing TP"
+
+    def test_api_models_have_api_id(self):
+        api_models = ["glm-5", "kimi-k2.5", "deepseek-v3.2"]
+        for name in api_models:
+            cfg = MODELS[name]
+            assert cfg.api_id is not None, f"{name} missing api_id"
+            assert cfg.vllm_args == {}, f"{name} should have no vllm_args"


### PR DESCRIPTION
## Summary

- Add 3 Nebius API model presets: `glm-5`, `kimi-k2.5`, `deepseek-v3.2`
- Update `smoke_test.py` with per-role models (GLM-5=generator, DeepSeek-V3.2=target, Kimi-K2.5=judge)
- Clean up `.env.example`

## Test plan

- [x] 81/81 tests pass
- [ ] Run `uv run python smoke_test.py` against Nebius